### PR TITLE
Ensure that upload file in the MediaPicker is returned

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/infiniteeditors/mediapicker/mediapicker.controller.js
@@ -330,7 +330,7 @@ angular.module("umbraco")
                             var images = _.rest($scope.images, $scope.images.length - files.length);
                             images.forEach(image => selectMedia(image));
                         } else {
-                            var image = $scope.images[$scope.images.length - 1];
+                            var image = _.sortBy($scope.images, 'id').reverse()[0];
                             clickHandler(image);
                         }
                     });


### PR DESCRIPTION
When you use another sorting for Media items than the default (we sort Media-items automatically by name alphabetically when they are created/uploaded), the onUploadComplete function doesn't return the last uploaded file. Instead is returns the last file in the folder. By sorting the files by Id, it ensures that the last added/uploaded file is returned instead of the last file in the list.
